### PR TITLE
Add ability to push/unshift multiple values at once - thanks @pomaxa

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,9 +603,11 @@ $a->previous(); // 'b'
 
 ``` php
 $a = MutableArray::create(['a', 'b', 'c']);
-$a->push('d');
-$a->toArray(); // [0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd']
+$a->push('d', 'e', 'f');
+$a->toArray(); // [0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd', 4 => 'e', 5 => 'f']
 ```
+
+> Method `push()` allow multiple arguments.
 
 ### reduce
 
@@ -735,10 +737,12 @@ $a->toArray(); // [0 => 'a', 1 => 'b', 3 => 'c']
 ### unshift
 
 ``` php
-$a = MutableArray::create(['b', 'c']);
-$a->unshift('a');
-$a->toArray(); // [0 => 'a', 1 => 'b', 2 => 'c']
+$a = MutableArray::create([('a', 'b', 'c']);
+$a->unshift('x', 'y', 'z');
+$a->toArray(); // [0 => 'x', 1 => 'y', 2 => 'z', 3 => 'a', 4 => 'b', 5 => 'c']
 ```
+
+> Method `unshift()` allow multiple arguments.
 
 ### walk
 

--- a/README.md
+++ b/README.md
@@ -602,9 +602,9 @@ $a->previous(); // 'b'
 ### push
 
 ``` php
-$a = MutableArray::create(['a', 'b', 'c']);
-$a->push('d', 'e', 'f');
-$a->toArray(); // [0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd', 4 => 'e', 5 => 'f']
+$a = MutableArray::create(['a', 'b']);
+$a->push('c', 'd');
+$a->toArray(); // [0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd']
 ```
 
 > Method `push()` allow multiple arguments.
@@ -737,9 +737,9 @@ $a->toArray(); // [0 => 'a', 1 => 'b', 3 => 'c']
 ### unshift
 
 ``` php
-$a = MutableArray::create([('a', 'b', 'c']);
-$a->unshift('x', 'y', 'z');
-$a->toArray(); // [0 => 'x', 1 => 'y', 2 => 'z', 3 => 'a', 4 => 'b', 5 => 'c']
+$a = MutableArray::create([('a', 'b']);
+$a->unshift('y', 'z');
+$a->toArray(); // [0 => 'y', 1 => 'z', 2 => 'a', 3 => 'b']
 ```
 
 > Method `unshift()` allow multiple arguments.

--- a/src/Interfaces/ModifiableInterface.php
+++ b/src/Interfaces/ModifiableInterface.php
@@ -15,13 +15,14 @@ interface ModifiableInterface
     public function shift();
 
     /**
-     * Prepends a new value to the beginning of array.
+     * Prepends one or more values to the beginning of array at once.
      *
      * @param mixed $element The element for prepend
+     * @param mixed $_ [optional] Multiple arguments allowed
      *
-     * @return $this The same instance with prepended element to the beginning of array
+     * @return $this The same instance with prepended elements to the beginning of array
      */
-    public function unshift($element);
+    public function unshift($element, $_ = null);
 
     /**
      * Pop a specified value off the end of array.
@@ -31,11 +32,12 @@ interface ModifiableInterface
     public function pop();
 
     /**
-     * Push value onto the end of array.
+     * Push one or more values onto the end of array at once.
      *
      * @param mixed $element The pushed element
+     * @param mixed $_ [optional] Multiple arguments allowed
      *
-     * @return $this The same instance with pushed element to the end of array
+     * @return $this The same instance with pushed elements to the end of array
      */
-    public function push($element);
+    public function push($element, $_ = null);
 }

--- a/src/Traits/ModifiableTrait.php
+++ b/src/Traits/ModifiableTrait.php
@@ -32,7 +32,10 @@ trait ModifiableTrait
      */
     public function unshift($element)
     {
-        array_unshift($this->elements, $element);
+        if (func_num_args()) {
+            $args = array_merge([&$this->elements], func_get_args());
+            call_user_func_array('array_unshift', $args);
+        }
 
         return $this;
     }
@@ -60,7 +63,10 @@ trait ModifiableTrait
      */
     public function push($element)
     {
-        array_push($this->elements, $element);
+        if (func_num_args()) {
+            $args = array_merge([&$this->elements], func_get_args());
+            call_user_func_array('array_push', $args);
+        }
 
         return $this;
     }

--- a/src/Traits/ModifiableTrait.php
+++ b/src/Traits/ModifiableTrait.php
@@ -22,15 +22,16 @@ trait ModifiableTrait
     }
 
     /**
-     * Prepends a new value to the beginning of array.
+     * Prepends one or more values to the beginning of array at once.
      *
      * @param mixed $element The element for prepend
+     * @param mixed $_ [optional] Multiple arguments allowed
      *
-     * @return $this The same instance with prepended element to the beginning of array
+     * @return $this The same instance with prepended elements to the beginning of array
      *
      * @link http://php.net/manual/en/function.array-unshift.php
      */
-    public function unshift($element)
+    public function unshift($element, $_ = null)
     {
         if (func_num_args()) {
             $args = array_merge([&$this->elements], func_get_args());
@@ -53,15 +54,16 @@ trait ModifiableTrait
     }
 
     /**
-     * Push value onto the end of array.
+     * Push one or more values onto the end of array at once.
      *
      * @param mixed $element The pushed element
+     * @param mixed $_ [optional] Multiple arguments allowed
      *
-     * @return $this The same instance with pushed element to the end of array
+     * @return $this The same instance with pushed elements to the end of array
      *
      * @link http://php.net/manual/en/function.array-push.php
      */
-    public function push($element)
+    public function push($element, $_ = null)
     {
         if (func_num_args()) {
             $args = array_merge([&$this->elements], func_get_args());

--- a/tests/ImmutableArrayTest.php
+++ b/tests/ImmutableArrayTest.php
@@ -555,10 +555,11 @@ class ImmutableArrayTest extends PHPUnit_Framework_TestCase
      */
     public function testUnshift(array $array)
     {
-        $newElement = 5;
+        $newElement1 = 5;
+        $newElement2 = 10;
         $ma = new ImmutableArray($array);
-        $copiedMa = $ma->unshift($newElement);
-        array_unshift($array, $newElement);
+        $copiedMa = $ma->unshift($newElement1, $newElement2);
+        array_unshift($array, $newElement1, $newElement2);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($array === $copiedMa->toArray());
@@ -582,10 +583,11 @@ class ImmutableArrayTest extends PHPUnit_Framework_TestCase
      */
     public function testPush(array $array)
     {
-        $newElement = 5;
+        $newElement1 = 5;
+        $newElement2 = 10;
         $ma = new ImmutableArray($array);
-        $copiedMa = $ma->push($newElement);
-        array_push($array, $newElement);
+        $copiedMa = $ma->push($newElement1, $newElement2);
+        array_push($array, $newElement1, $newElement2);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($array === $copiedMa->toArray());


### PR DESCRIPTION
Alternative improvement of `push`/`unshift` methods discussed in https://github.com/bocharsky-bw/Arrayzy/pull/9 .

``` php
$a = Arrayzy\MutableArray::create(['a', 'b', 'c']);
$a->push('d', 'e', 'f');
$a->unshift('x', 'y', 'z');
$a->debug();
```

output is:

```
Array
(
    [0] => x
    [1] => y
    [2] => z
    [3] => a
    [4] => b
    [5] => c
    [6] => d
    [7] => e
    [8] => f
)
```
