### PR TITLE
Rename some methods which difficult to understand

### DIFF
--- a/src/AbstractArray.php
+++ b/src/AbstractArray.php
@@ -142,7 +142,7 @@ abstract class AbstractArray implements
      *
      * @return static The instance array with merged elements
      */
-    abstract public function mergeTo(array $array, $recursively = false);
+    abstract public function useAndMergeTo(array $array, $recursively = false);
 
     /**
      * Replace array with given one
@@ -162,7 +162,7 @@ abstract class AbstractArray implements
      *
      * @return static The instance array with replaced elements
      */
-    abstract public function replaceIn(array $array, $recursively = false);
+    abstract public function useAndReplaceIn(array $array, $recursively = false);
 
     /**
      * Combine array values used as keys with a given array values
@@ -180,7 +180,7 @@ abstract class AbstractArray implements
      *
      * @return static The instance array with combined elements
      */
-    abstract public function combineTo(array $array);
+    abstract public function useAndCombineTo(array $array);
 
     /**
      * Compute the difference of array with given one

--- a/src/ImmutableArray.php
+++ b/src/ImmutableArray.php
@@ -120,7 +120,7 @@ class ImmutableArray extends AbstractArray
      *
      * @return static The new instance with merged elements
      */
-    public function mergeTo(array $array, $recursively = false)
+    public function useAndMergeTo(array $array, $recursively = false)
     {
         if (true === $recursively) {
             return new static(array_merge_recursive($array, $this->elements));
@@ -154,7 +154,7 @@ class ImmutableArray extends AbstractArray
      *
      * @return static The new instance with replaced elements
      */
-    public function replaceIn(array $array, $recursively = false)
+    public function useAndReplaceIn(array $array, $recursively = false)
     {
         if (true === $recursively) {
             return new static(array_replace_recursive($array, $this->elements));
@@ -182,7 +182,7 @@ class ImmutableArray extends AbstractArray
      *
      * @return static The new instance with combined elements
      */
-    public function combineTo(array $array)
+    public function useAndCombineTo(array $array)
     {
         return new static(array_combine($array, $this->elements));
     }

--- a/src/MutableArray.php
+++ b/src/MutableArray.php
@@ -136,7 +136,7 @@ class MutableArray extends AbstractArray
      *
      * @return $this The same instance with merged elements
      */
-    public function mergeTo(array $array, $recursively = false)
+    public function useAndMergeTo(array $array, $recursively = false)
     {
         if (true === $recursively) {
             $this->elements = array_merge_recursive($array, $this->elements);
@@ -174,7 +174,7 @@ class MutableArray extends AbstractArray
      *
      * @return $this The same instance with replaced elements
      */
-    public function replaceIn(array $array, $recursively = false)
+    public function useAndReplaceIn(array $array, $recursively = false)
     {
         if (true === $recursively) {
             $this->elements = array_replace_recursive($array, $this->elements);
@@ -206,7 +206,7 @@ class MutableArray extends AbstractArray
      *
      * @return $this The same instance with combined elements
      */
-    public function combineTo(array $array)
+    public function useAndCombineTo(array $array)
     {
         $this->elements = array_combine($array, $this->elements);
 

--- a/tests/ImmutableArrayTest.php
+++ b/tests/ImmutableArrayTest.php
@@ -202,7 +202,7 @@ class ImmutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testMergeTo(array $array)
+    public function testUseAndMergeTo(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -211,7 +211,7 @@ class ImmutableArrayTest extends AbstractArrayTest
         ];
         $mergedArray = array_merge($secondArray, $array);
         $ma = new ImmutableArray($array);
-        $copiedMa = $ma->mergeTo($secondArray);
+        $copiedMa = $ma->useAndMergeTo($secondArray);
 
         $this->assertTrue($copiedMa !== $ma);
         $this->assertTrue($mergedArray === $copiedMa->toArray());
@@ -238,7 +238,7 @@ class ImmutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testMergeToRecursively(array $array)
+    public function testUseAndMergeToRecursively(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -247,7 +247,7 @@ class ImmutableArrayTest extends AbstractArrayTest
         ];
         $mergedArray = array_merge_recursive($secondArray, $array);
         $ma = new ImmutableArray($array);
-        $copiedMa = $ma->mergeTo($secondArray, true);
+        $copiedMa = $ma->useAndMergeTo($secondArray, true);
 
         $this->assertTrue($copiedMa !== $ma);
         $this->assertTrue($mergedArray === $copiedMa->toArray());
@@ -292,7 +292,7 @@ class ImmutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testReplaceIn(array $array)
+    public function testUseAndReplaceIn(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -301,7 +301,7 @@ class ImmutableArrayTest extends AbstractArrayTest
         ];
         $replacedArray = array_replace($secondArray, $array);
         $ma = new ImmutableArray($array);
-        $copiedMa = $ma->replaceIn($secondArray);
+        $copiedMa = $ma->useAndReplaceIn($secondArray);
 
         $this->assertTrue($copiedMa !== $ma);
         $this->assertTrue($replacedArray === $copiedMa->toArray());
@@ -310,7 +310,7 @@ class ImmutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testReplaceInRecursively(array $array)
+    public function testUseAndReplaceInRecursively(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -319,13 +319,13 @@ class ImmutableArrayTest extends AbstractArrayTest
         ];
         $replacedArray = array_replace_recursive($secondArray, $array);
         $ma = new ImmutableArray($array);
-        $copiedMa = $ma->replaceIn($secondArray, true);
+        $copiedMa = $ma->useAndReplaceIn($secondArray, true);
 
         $this->assertTrue($copiedMa !== $ma);
         $this->assertTrue($replacedArray === $copiedMa->toArray());
     }
 
-    public function testCombineTo()
+    public function testUseAndCombineTo()
     {
         $firstArray = [
             1 => 'one',
@@ -339,7 +339,7 @@ class ImmutableArrayTest extends AbstractArrayTest
         ];
         $combinedArray = array_combine($secondArray, $firstArray);
         $ma = new ImmutableArray($firstArray);
-        $copiedMa = $ma->combineTo($secondArray);
+        $copiedMa = $ma->useAndCombineTo($secondArray);
 
         $this->assertTrue($copiedMa !== $ma);
         $this->assertTrue($combinedArray === $copiedMa->toArray());

--- a/tests/MutableArrayTest.php
+++ b/tests/MutableArrayTest.php
@@ -219,7 +219,7 @@ class MutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testMergeTo(array $array)
+    public function testUseAndMergeTo(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -228,7 +228,7 @@ class MutableArrayTest extends AbstractArrayTest
         ];
         $mergedArray = array_merge($secondArray, $array);
         $ma = new MutableArray($array);
-        $copiedMa = $ma->mergeTo($secondArray);
+        $copiedMa = $ma->useAndMergeTo($secondArray);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($mergedArray === $ma->toArray());
@@ -255,7 +255,7 @@ class MutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testMergeToRecursively(array $array)
+    public function testUseAndMergeToRecursively(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -264,7 +264,7 @@ class MutableArrayTest extends AbstractArrayTest
         ];
         $mergedArray = array_merge_recursive($secondArray, $array);
         $ma = new MutableArray($array);
-        $copiedMa = $ma->mergeTo($secondArray, true);
+        $copiedMa = $ma->useAndMergeTo($secondArray, true);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($mergedArray === $ma->toArray());
@@ -309,7 +309,7 @@ class MutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testReplaceIn(array $array)
+    public function testUseAndReplaceIn(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -318,7 +318,7 @@ class MutableArrayTest extends AbstractArrayTest
         ];
         $replacedArray = array_replace($secondArray, $array);
         $ma = new MutableArray($array);
-        $copiedMa = $ma->replaceIn($secondArray);
+        $copiedMa = $ma->useAndReplaceIn($secondArray);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($replacedArray === $ma->toArray());
@@ -327,7 +327,7 @@ class MutableArrayTest extends AbstractArrayTest
     /**
      * @dataProvider simpleArrayProvider
      */
-    public function testReplaceInRecursively(array $array)
+    public function testUseAndReplaceInRecursively(array $array)
     {
         $secondArray = [
             'one' => 1,
@@ -336,13 +336,13 @@ class MutableArrayTest extends AbstractArrayTest
         ];
         $replacedArray = array_replace_recursive($secondArray, $array);
         $ma = new MutableArray($array);
-        $copiedMa = $ma->replaceIn($secondArray, true);
+        $copiedMa = $ma->useAndReplaceIn($secondArray, true);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($replacedArray === $ma->toArray());
     }
 
-    public function testCombineTo()
+    public function testUseAndCombineTo()
     {
         $firstArray = [
             1 => 'one',
@@ -356,7 +356,7 @@ class MutableArrayTest extends AbstractArrayTest
         ];
         $combinedArray = array_combine($secondArray, $firstArray);
         $ma = new MutableArray($firstArray);
-        $copiedMa = $ma->combineTo($secondArray);
+        $copiedMa = $ma->useAndCombineTo($secondArray);
 
         $this->assertTrue($copiedMa === $ma);
         $this->assertTrue($combinedArray === $ma->toArray());


### PR DESCRIPTION
Rename some methods which difficult to understand without docs.

Thanks @nyamsprod to point it in his [comment](https://www.reddit.com/r/PHP/comments/3nysjn/the_wrapper_for_all_php_internal_builtin_array/cvsgcer).
